### PR TITLE
Export credentials as JSON, for use as an AWS CLI external process

### DIFF
--- a/awssso/cli.py
+++ b/awssso/cli.py
@@ -139,7 +139,7 @@ def login(args):
             ], answers=params, raise_keyboard_interrupt=True)
 
         payload = sso.get_saml_payload(params['instance_id'], params['profile_id'])
-        saml = SAMLHelper(aws_profile, payload)
+        saml = SAMLHelper(payload)
         credentials = saml.assume_role(args.duration)['Credentials']
 
         ch = CredentialsHelper(credentials)

--- a/awssso/cli.py
+++ b/awssso/cli.py
@@ -139,13 +139,15 @@ def login(args):
             ], answers=params, raise_keyboard_interrupt=True)
 
         payload = sso.get_saml_payload(params['instance_id'], params['profile_id'])
-        saml = SAMLHelper(payload)
+        saml = SAMLHelper(aws_profile, payload)
         credentials = saml.assume_role(args.duration)['Credentials']
 
         ch = CredentialsHelper(credentials)
 
         if args.export:
             print(ch.configure_export())
+        elif args.json:
+            print(ch.configure_json())
         elif args.console:
             session_duration = args.duration or saml.duration
             signin_url = ch.console_signin(session_duration)
@@ -196,6 +198,7 @@ def main():
     login_parser.add_argument('-d', '--duration', action=DurationAction, type=int, help='duration (seconds) of the role session (default/maximum: from SAML payload, minimum: 900)')
     login_parser_group = login_parser.add_mutually_exclusive_group()
     login_parser_group.add_argument('-e', '--export', action='store_true', default=False, help='output credentials as environment variables')
+    login_parser_group.add_argument('-j', '--json', action='store_true', default=False, help='output credentials in JSON format (see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html)')
     login_parser_group.add_argument('-c', '--console', action='store_true', default=False, help='output AWS Console Sign In url')
     login_parser.add_argument('-b', '--browser', action='store_true', default=False, help='open web browser with AWS Console Sign In url')
     login_parser.add_argument('-i', '--interactive', action='store_true', default=False, help='interactively choose AWS account and role')

--- a/awssso/helpers.py
+++ b/awssso/helpers.py
@@ -71,6 +71,16 @@ class CredentialsHelper():
                 exports.append(export)
         return '\n'.join(exports)
 
+    def configure_json(self):
+        export = {
+            **self._credentials,
+            **{
+                'Version': 1,
+                'Expiration': self._credentials['Expiration'].isoformat()
+            }
+        }
+        return json.dumps(export)
+
     def console_signin(self, duration):
         session = {}
         for _ in self._credentials:

--- a/awssso/saml.py
+++ b/awssso/saml.py
@@ -43,9 +43,11 @@ class SAMLHelper():
         'duration': ".//a:Assertion/a:AttributeStatement/a:Attribute[@Name='https://aws.amazon.com/SAML/Attributes/SessionDuration']/a:AttributeValue"
     }
 
-    def __init__(self, aws_profile, encoded_payload):
-        self._session = boto3.Session(profile_name=aws_profile)
-        self._sts = self._session.client('sts')
+    def __init__(self, encoded_payload):
+        # Calling AssumeRoleWithSAML does not require the use of AWS security credentials.
+        # The identity of the caller is validated by using keys in the metadata document that is uploaded for the SAML provider entity for your identity provider.
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html#STS.Client.assume_role_with_saml
+        self._sts = boto3.client('sts', aws_access_key_id='', aws_secret_access_key='', aws_session_token='')
         self._root = ET.fromstring(b64decode(encoded_payload))
         self._role_arn, self._principal_arn = self._get_roles()
         self._duration = self._get_duration()

--- a/awssso/saml.py
+++ b/awssso/saml.py
@@ -43,8 +43,9 @@ class SAMLHelper():
         'duration': ".//a:Assertion/a:AttributeStatement/a:Attribute[@Name='https://aws.amazon.com/SAML/Attributes/SessionDuration']/a:AttributeValue"
     }
 
-    def __init__(self, encoded_payload):
-        self._sts = boto3.client('sts')
+    def __init__(self, aws_profile, encoded_payload):
+        self._session = boto3.Session(profile_name=aws_profile)
+        self._sts = self._session.client('sts')
         self._root = ET.fromstring(b64decode(encoded_payload))
         self._role_arn, self._principal_arn = self._get_roles()
         self._duration = self._get_duration()

--- a/awssso/ssodriver.py
+++ b/awssso/ssodriver.py
@@ -2,7 +2,7 @@ import pickle
 from hashlib import sha256
 
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -134,7 +134,7 @@ class SSODriver():
             error = alert.find_element_by_css_selector('div.a-alert-error > div.a-box-inner > h4').text
             message = alert.find_element_by_css_selector('div.a-alert-error > div.a-box-inner > div.gwt-Label').text
             raise AlertMessage(f'{error}: {message}')
-        except TimeoutException:
+        except (TimeoutException, NoSuchElementException):
             pass
 
     def check_mfa(self):


### PR DESCRIPTION
Hi there @wnkz , thanks a lot for this excellent utility!

I've been testing it out locally and it makes AWS SSO from the CLI much more pleasant. I made some local tweaks so that I can use `aws-sso` in the `credential_process` section of the AWS CLI configuration as described [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html). Would you be interested in having that merged back upstream (either as-is, or with any modifications you think are necessary)?