### PR TITLE
Use a consistent duration for console URL requests

### DIFF
--- a/awssso/helpers.py
+++ b/awssso/helpers.py
@@ -92,10 +92,6 @@ class CredentialsHelper():
         return self.credentials['Expiration']
 
     @property
-    def duration(self):
-        return int((self.expiration - datetime.now(timezone.utc)).total_seconds())
-
-    @property
     def expired(self):
         return self.expiration < datetime.now(timezone.utc)
 
@@ -119,7 +115,6 @@ class CredentialsHelper():
         }, default=json_serial)
 
     def to_console_url(self, duration=None):
-        duration = duration or self.duration
         params = {
             'Action': 'getSigninToken',
             'Session': json.dumps(self.console),


### PR DESCRIPTION
The cached credentials from #9 are a great improvement, nice!

Since that change, I came across a flaky issue that seems external to this project: my `awssso -c` calls were failing sporadically, and I narrowed it down to a reproducible issue with some durations in the `getSigninToken` request.

As an example, in one case I was able to reproducibly get `HTTP 400 Bad Request` using a `getSigninToken` request with a duration of `7273`. Changing only the duration (either lower to `900` or higher to `43200`) consistently worked. Strange.

I'm wondering if the console session duration should fall back to a default/none if there's no CLI argument, rather than being based on the remaining time of the cached credentials. That avoids the weird flaky federation error response (if only as a side effect), and seems like more consistent behavior. What do you think?