### PR TITLE
Increase timeout length

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ brew cask install chromedriver
 ## Installation
 
 ```shell
+# Remote repository
 pip install awssso
+
+# Local filepath
+# https://packaging.python.org/tutorials/installing-packages/#installing-from-a-local-src-tree
+pip install .
 ```
 
 ## Getting Started

--- a/awssso/ssodriver.py
+++ b/awssso/ssodriver.py
@@ -75,13 +75,13 @@ class SSODriver():
                 cookies.append(cookie)
         pickle.dump(cookies, open(self._cookie_file, 'wb'))
 
-    def _find_element_by_id(self, element_id, driver=None, timeout=5):
+    def _find_element_by_id(self, element_id, driver=None, timeout=30):
         driver = driver or self._driver
         return WebDriverWait(driver, timeout, poll_frequency=self._poll_frequency).until(
             EC.visibility_of_element_located((By.ID, element_id))
         )
 
-    def _click_element_by_id(self, element_id, driver=None, timeout=5):
+    def _click_element_by_id(self, element_id, driver=None, timeout=30):
         element = self._find_element_by_id(element_id, driver, timeout)
         element.click()
         return element


### PR DESCRIPTION
While AWS has released sso in their CLI, this tool is still useful for programmatic reasons and avoid having the user to visit AWS SSO page to manually copy credentials. This reason is sufficient to make me continue using it. 